### PR TITLE
Uncommented output_velocity and velocityfname for lognormal_galaxies.

### DIFF
--- a/simple/run_lognormal_galaxies.py
+++ b/simple/run_lognormal_galaxies.py
@@ -216,8 +216,8 @@ def gen_Poisson(i, params, seed1, seed2, seed3, exe):
         "Densityfname",
         "output_matter",
         "output_gal",
-        #"Velocityfname",
-        #"output_velocity"
+        "Velocityfname",
+        "output_velocity"
     ]  # do not change the order
     exe.run(
         os.path.join(main_lognormal_path, "generate_Poisson/gen_Poisson_mock_LogNormal"),


### PR DESCRIPTION
The 'intensity-mapping' branch of lognormal_galaxies was updated, therefore we have to output the 'output_velocity' and 'velocityfname' parameters to run the lognormal_galaxies code correctly.